### PR TITLE
AE: fix Project.itemByID() method

### DIFF
--- a/AfterEffects/13.0/index.d.ts
+++ b/AfterEffects/13.0/index.d.ts
@@ -1630,7 +1630,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/13.1/index.d.ts
+++ b/AfterEffects/13.1/index.d.ts
@@ -1630,7 +1630,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/13.2/index.d.ts
+++ b/AfterEffects/13.2/index.d.ts
@@ -1636,7 +1636,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/13.6/index.d.ts
+++ b/AfterEffects/13.6/index.d.ts
@@ -1641,7 +1641,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/13.8/index.d.ts
+++ b/AfterEffects/13.8/index.d.ts
@@ -1654,7 +1654,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/14.0/index.d.ts
+++ b/AfterEffects/14.0/index.d.ts
@@ -1706,7 +1706,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/14.2/index.d.ts
+++ b/AfterEffects/14.2/index.d.ts
@@ -1706,7 +1706,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/15.0/index.d.ts
+++ b/AfterEffects/15.0/index.d.ts
@@ -1716,7 +1716,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/16.0/index.d.ts
+++ b/AfterEffects/16.0/index.d.ts
@@ -1741,7 +1741,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/16.1/index.d.ts
+++ b/AfterEffects/16.1/index.d.ts
@@ -1759,7 +1759,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/17.0/index.d.ts
+++ b/AfterEffects/17.0/index.d.ts
@@ -1760,7 +1760,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/17.1/index.d.ts
+++ b/AfterEffects/17.1/index.d.ts
@@ -1763,7 +1763,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/18.0/index.d.ts
+++ b/AfterEffects/18.0/index.d.ts
@@ -1775,7 +1775,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/22.0/index.d.ts
+++ b/AfterEffects/22.0/index.d.ts
@@ -1786,7 +1786,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/22.3/index.d.ts
+++ b/AfterEffects/22.3/index.d.ts
@@ -1796,7 +1796,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/22.6/index.d.ts
+++ b/AfterEffects/22.6/index.d.ts
@@ -1796,7 +1796,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number

--- a/AfterEffects/23.0/index.d.ts
+++ b/AfterEffects/23.0/index.d.ts
@@ -1811,7 +1811,7 @@ declare class Project {
   item(index: number): _ItemClasses
 
   /** Retrieves an item by its Item ID */
-  itemById(id: number): _ItemClasses
+  itemByID(id: number): _ItemClasses
 
   /** Consolidates all footage in the project. */
   consolidateFootage(): number


### PR DESCRIPTION
Fixes a small typo in the definitions for After Effects, from versions 13.0 onwards – the case doesn't match the [Project.itemByID() method in the AE API](https://ae-scripting.docsforadobe.dev/general/project.html?highlight=itembyid#project-itembyid).