### PR TITLE
[ScriptUI] `onClose` _can_ return false to cancel, but it is not required

### DIFF
--- a/shared/ScriptUI.d.ts
+++ b/shared/ScriptUI.d.ts
@@ -346,7 +346,7 @@ declare class Window extends _Control {
    * An event-handler callback function, called when the window is about to be closed.
    * Called when a request is made to close the window, either by an explicit call to the close() function or by a user action (clicking the OS-specific close icon in the title bar). The function is called before the window actually closes; it can return false to cancel the close operation.
    */
-  onClose(): boolean
+  onClose(): void | boolean
 
   /**
    * An event-handler callback function, called when the window loses the keyboard focus.


### PR DESCRIPTION
The current definition of the `onClosed` callback says:

> ...The function is called before the window actually closes; it **can** return false to cancel the close operation.

But, the type suggests a boolean **must** be returned:

https://github.com/docsforadobe/Types-for-Adobe/blob/e84efafa2decdb6e6f8c4c043d20f26949f5836f/shared/ScriptUI.d.ts#L349

This PR updates the return type to `void | boolean`.