### PR TITLE
[ScriptUI] add `Window.findElement`

### DIFF
--- a/shared/ScriptUI.d.ts
+++ b/shared/ScriptUI.d.ts
@@ -2698,6 +2698,11 @@ declare class _Control {
   dispatchEvent(): Event
 
   /**
+   * Searches for the named element among the children of this window or container, and returns the object if found.
+   */
+  findElement(name: string): _Control | null
+
+  /**
    * Hides this element.
    */
   hide(): void


### PR DESCRIPTION
`Window.findElement()` [is documented](https://extendscript.docsforadobe.dev/user-interface-tools/window-object/?h=findelemen#findelement), but it is not present in type definitions. 

This PR adds `findElement(name: string): _Control | null`. Although, I'm not sure if that is the preferred return type. Would we want to be explicit and list the control types?

```ts
findElement(
    name: string,
  ):
    | Button
    | Checkbox
    | DropDownList
    | EditText
    | FlashPlayer
    | Group
    | IconButton
    | Image
    | ListBox
    | Panel
    | Progressbar
    | RadioButton
    | Scrollbar
    | Slider
    | StaticText
    | TabbedPanel
    | TreeView
    | null
```