### PR TITLE
[JavaScript] `String.concat` accepts any number of `any` values

### DIFF
--- a/shared/JavaScript.d.ts
+++ b/shared/JavaScript.d.ts
@@ -1008,7 +1008,7 @@ interface String {
    * Those values are concatenated with the original string, the result is returned. The original string is not effected.Returns the concatenated string.
    * @param value The values to be concatenated with the given string.
    */
-  concat(...value: string[]): string
+  concat(...value: any[]): string
 
   /**
    * Returns a string consisting of this string enclosed in a <tt> tag.

--- a/shared/JavaScript.d.ts
+++ b/shared/JavaScript.d.ts
@@ -1008,7 +1008,7 @@ interface String {
    * Those values are concatenated with the original string, the result is returned. The original string is not effected.Returns the concatenated string.
    * @param value The values to be concatenated with the given string.
    */
-  concat(value: string): string
+  concat(...value: string[]): string
 
   /**
    * Returns a string consisting of this string enclosed in a <tt> tag.


### PR DESCRIPTION
The current definition of the `String.concat` says it will:

> **converts** the one **or more** given values to strings...

But, the type suggests a it only accepts a single `string` value:

https://github.com/docsforadobe/Types-for-Adobe/blob/6953648c1513bd4acd08b562e9ebb447dc33124d/shared/JavaScript.d.ts#L1006-L1011

This PR updates the parameters to `...values: any[]`.

```js
// test-in-ae.jsx
alert(
  "".concat(
    { key: "value", prop: ["test"] },
    ["array", 1, { two: "three" }],
    "string",
    function test() {
      return true;
    },
    false,
    100
  ),
);

```