### PR TITLE
[JavaScript] `String.split` accepts `RegExp` as delimiter

### DIFF
--- a/shared/JavaScript.d.ts
+++ b/shared/JavaScript.d.ts
@@ -1097,7 +1097,7 @@ interface String {
    * @param delimiter Specifies the string to use for delimiting. If delimiter is omitted, the array returned contains one element, consisting of the entire string.
    * @param limit
    */
-  split(delimiter: string, limit?: number): string[]
+  split(delimiter: string | RegExp, limit?: number): string[]
 
   /**
    * Returns a string consisting of this string enclosed in a <strike> tag.


### PR DESCRIPTION
The current types for `String.split` only allows for `string` delimiters:

https://github.com/docsforadobe/Types-for-Adobe/blob/67bcaf76bab03dcb790bf240256c333a3d00e608/shared/JavaScript.d.ts#L1094-L1100

But this will work:

```js
// test-in-ae.jsx
alert("Hello there, pal!".split(/[\s,]+/).length)
```

This PR adds `RegExp` to type:

```ts
split(delimiter: string | RegExp, limit?: number): string[]
```