### PR TITLE
[ScriptUI] reference `enum`s with `typeof` to properly access enum values

### DIFF
--- a/shared/ScriptUI.d.ts
+++ b/shared/ScriptUI.d.ts
@@ -62,13 +62,13 @@ declare class ScriptUI {
    * Collects the enumerated values that can be used in the alignment and alignChildren properties of controls and containers.
    * Predefined alignment values are: TOP, BOTTOM, LEFT, RIGHT, FILL, CENTER
    */
-  static readonly Alignment: _Alignment
+  static readonly Alignment: typeof _Alignment
 
   /**
    * Collects the enumerated values that can be used as the style argument to the ScriptUI.newFont() method.
    * Predefined styles are REGULAR, BOLD, ITALIC, BOLDITALIC.
    */
-  static readonly FontStyle: _FontStyle
+  static readonly FontStyle: typeof _FontStyle
 
   /**
    * The font constants defined by the host application.
@@ -493,13 +493,13 @@ declare class ScriptUIGraphics {
    * Contains the enumerated constants for the type argument of newBrush().
    * Type constants are: SOLID_COLOR, THEME_COLOR.
    */
-  static readonly BrushType: _BrushOrPenType
+  static readonly BrushType: typeof _BrushOrPenType
 
   /**
    * Contains the enumerated constants for the type argument of newPen().
    * Type constants are: SOLID_COLOR, THEME_COLOR.
    */
-  static readonly PenType: _BrushOrPenType
+  static readonly PenType: typeof _BrushOrPenType
 
   /**
    * The background color for containers; for non-containers, the parent background color.


### PR DESCRIPTION
The following lines work in ExtendScript, but will cause TypeScript to complain with (ts 2339):

```ts
ScriptUI.Alignment.LEFT // Property 'LEFT' does not exist on type '_Alignment'. 
ScriptUI.FontStyle.BOLD // Property 'BOLD' does not exist on type '_FontStyle'.
ScriptUIGraphics.PenType.SOLID_COLOR // Property 'SOLID_COLOR' does not exist on type '_BrushOrPenType'.
```

This is because in order to access the `enum` values we need to reference their types via `typeof`. This PR adds this:

```ts
declare class ScriptUI {
  static readonly Alignment: typeof _Alignment
  static readonly FontStyle: typeof _FontStyle
}

declare class ScriptUIGraphics {
  static readonly BrushType: typeof _BrushOrPenType
  static readonly PenType: typeof _BrushOrPenType
}
```