### PR TITLE
Add MIT license to repo

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-Present types-for-adobe contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ tsc
 
 Everything in this project was generated through one of the following methods:
 
-1. Using this [extendscript-xml-to-typescript converter](https://github.com/aenhancers/extendscript-xml-to-typescript) tool to convert scripting dictionaries to typedef format
+1. Using this [extendscript-xml-to-typescript converter](https://github.com/bbb999/extendscript-xml-to-typescript) tool to convert scripting dictionaries to typedef format
    - *note that this only works for a few select apps, and has been found to generate incorrect data in some cases*
 2. By hand, through referencing Adobe's official release announcements & developer exploration through the API.
 
@@ -76,15 +76,15 @@ This really depends on your needs; if you're hoping to release a commercial tool
 Two possible answers! Either
 
 1. There haven't been any API changes for that given version, or
-2. Nobody's taken the time to add typedefs for that version; feel free to [open a PR](https://github.com/aenhancers/Types-for-Adobe/pulls)!
+2. Nobody's taken the time to add typedefs for that version; feel free to [open a PR](https://github.com/docsforadobe/Types-for-Adobe/pulls)!
 
 ---
 
 ## Contributors
 
-Thanks to [all of our contributors](https://github.com/aenhancers/Types-for-Adobe/graphs/contributors) for helping make this project succeed!
+Thanks to [all of our contributors](https://github.com/docsforadobe/Types-for-Adobe/graphs/contributors) for helping make this project succeed!
 
-Have something to add? Please [open a PR](https://github.com/aenhancers/Types-for-Adobe/pulls)!
+Have something to add? Please [open a PR](https://github.com/docsforadobe/Types-for-Adobe/pulls)!
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/aenhancers/types-for-adobe.git"
+    "url": "https://github.com/docsforadobe/types-for-adobe.git"
   },
   "scripts": {
     "test": "_bin/test.sh"


### PR DESCRIPTION
Adds a broad MIT license to the repo.

Note that as far back as 2018, this package mentioned being licensed under MIT in package.json (but no explicit license file was ever committed reflecting this).

Will close #149.